### PR TITLE
Add error detection and admin notices for proxy failures (Refs #1)

### DIFF
--- a/src/Core/Admin/Admin.php
+++ b/src/Core/Admin/Admin.php
@@ -14,4 +14,35 @@ class Admin
         $settings = new Settings();
         $settings->register();
     }
+
+    /**
+     * Registers hooks for the admin area, including notices and future admin scripts/styles.
+     *
+     * @return void
+     */
+    public function registerHooks(): void
+    {
+        add_action('admin_notices', [$this, 'showProxyErrors']);
+    }
+
+    /**
+     * Displays an admin notice if a proxy error has been stored in a transient.
+     *
+     * This method checks for the 'lmcdn_last_proxy_error' transient and, if set,
+     * outputs a dismissible admin error notice in the WordPress dashboard.
+     *
+     * @return void
+     */
+    public function showProxyErrors(): void
+    {
+        $screen = get_current_screen();
+        if (!$screen || $screen->id !== 'tools_page_local-media-proxy') {
+            return;
+        }
+
+        $error = get_transient('lmcdn_last_proxy_error');
+        if ($error) {
+            echo '<div class="notice notice-error"><p>' . esc_html($error) . '</p></div>';
+        }
+    }
 }

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -109,6 +109,7 @@ class Core
     {
         // Register plugin settings, fields, and options page in the WordPress admin
         (new Admin())->register();
+        (new Admin())->registerHooks();
 
         // Register the media replacement proxy
         if (get_option('lmcdn_use_proxy', false)) {

--- a/src/Features/ProxyEndpoint.php
+++ b/src/Features/ProxyEndpoint.php
@@ -47,37 +47,69 @@ class ProxyEndpoint
      */
     public function handle_request(\WP_REST_Request $request)
     {
+        // Get and sanitize the 'key' parameter from the request
         $key = sanitize_text_field($request->get_param('key'));
+
+        // Retrieve the expected proxy secret key from plugin options
         $expected_key = get_option('lmcdn_proxy_secret', '');
+
+        // Validate the key: if missing or does not match, log and return 403 Unauthorized
         if (empty($expected_key) || $key !== $expected_key) {
+            set_transient('lmcdn_last_proxy_error', 'Proxy request failed: Invalid key.', 60);
             $this->log_attempt(false, 'Invalid key', $request);
             return new \WP_REST_Response(['error' => 'Unauthorized'], 403);
         }
 
+        // Get and sanitize the 'path' parameter from the request
         $path = sanitize_text_field($request->get_param('path'));
+
+        // Validate the path: it must not be empty
         if (!$path) {
+            set_transient('lmcdn_last_proxy_error', 'Proxy request failed: No path specified.', 60);
             $this->log_attempt(false, 'Missing path', $request);
+
             return new \WP_REST_Response(['error' => 'No path specified'], 400);
         }
 
+        // Get the absolute base path to the uploads directory
         $uploads = wp_get_upload_dir();
         $allowed_base = realpath($uploads['basedir']);
+
+        // Resolve the absolute path of the requested file inside uploads
         $resolved = realpath(trailingslashit($uploads['basedir']) . ltrim($path, '/'));
 
-        // Validate file path is inside uploads dir and exists
+        // Validate resolved path:
+        // - Must resolve successfully
+        // - Must be inside the uploads base directory (prevents path traversal)
+        // - Must exist on disk
         if (!$resolved || strpos($resolved, $allowed_base) !== 0 || !file_exists($resolved)) {
+            set_transient('lmcdn_last_proxy_error', 'Proxy request failed: File not found or outside uploads.', 60);
             $this->log_attempt(false, 'Invalid or missing file', $request);
+
             return new \WP_REST_Response(['error' => 'File not found'], 404);
         }
 
-        // TODO: Add rate limiting here in future.
+        // Placeholder for rate limiting logic in the future
 
+        // Log successful attempt
         $this->log_attempt(true, 'Served file', $request);
 
+        // Determine the MIME type of the file; default to binary if unknown
         $mime = wp_check_filetype($resolved)['type'] ?: 'application/octet-stream';
+
+        // Send the Content-Type header so the client knows the file type
         header('Content-Type: ' . $mime);
+
+        // Send caching headers to allow long-term browser caching
         header('Cache-Control: public, max-age=31536000');
+
+        // Clear the error transient before serving the file
+        delete_transient('lmcdn_last_proxy_error');
+
+        // Output the file content directly to the response
         readfile($resolved);
+
+        // Stop script execution after serving the file
         exit;
     }
 


### PR DESCRIPTION
- Detect invalid proxy requests (bad key, missing path, invalid file) and set a transient error message.
- Display a scoped admin notice with the error on the plugin settings page.
- Automatically clear the transient on successful proxy requests.
- Restrict admin notice to plugin settings page for cleaner admin experience.

Closes #1 